### PR TITLE
Fixes codable & equatable Swift doc links

### DIFF
--- a/src/Shwifty/Types.hs
+++ b/src/Shwifty/Types.hs
@@ -186,10 +186,10 @@ data Protocol
     --   See https://developer.apple.com/documentation/swift/hashable
   | Codable
     -- ^ The 'Codable' protocol.
-    --   See https://developer.apple.com/documentation/swift/hashable
+    --   See https://developer.apple.com/documentation/swift/codable
   | Equatable
     -- ^ The 'Equatable' protocol.
-    --   See https://developer.apple.com/documentation/swift/hashable
+    --   See https://developer.apple.com/documentation/swift/equatable
   | OtherProtocol String
     -- ^ A user-specified protocol.
   deriving stock (Eq, Read, Show, Generic)


### PR DESCRIPTION
Noticed this when skimming the library again, but it looks like there was a small copy/paste error between the `Hashable`, `Codable`, and `Equatable` protocol indicators.