### PR TITLE
Add ToSwiftData instances for Scientific and Value

### DIFF
--- a/shwifty.cabal
+++ b/shwifty.cabal
@@ -41,12 +41,14 @@ library
     Shwifty.Pretty
     Shwifty.Types
   build-depends:
+    , aeson >= 1.5 && < 2
     , base >= 4.11 && < 4.15
     , bytestring >= 0.10 && < 0.11
     , case-insensitive >= 1.2 && < 1.3
     , containers >= 0.5.9 && < 0.7
     , mtl >= 2.2 && < 2.3
     , primitive >= 0.6.4 && < 0.8
+    , scientific >= 0.3.6 && < 0.4
     , template-haskell >= 2.11 && < 2.17
     , text >= 1.2 && < 1.3
     , th-abstraction >= 0.3 && < 0.4

--- a/shwifty.cabal
+++ b/shwifty.cabal
@@ -41,7 +41,7 @@ library
     Shwifty.Pretty
     Shwifty.Types
   build-depends:
-    , aeson >= 1.5 && < 2
+    , aeson >= 1.0 && < 2
     , base >= 4.11 && < 4.15
     , bytestring >= 0.10 && < 0.11
     , case-insensitive >= 1.2 && < 1.3

--- a/src/Shwifty.hs
+++ b/src/Shwifty.hs
@@ -799,6 +799,7 @@ tyE = \case
   App e1 e2 -> AppE (AppE (ConE 'App) (tyE e1)) (tyE e2)
   Array e -> AppE (ConE 'Array) (tyE e)
   Tag{..} -> AppE (AppE (AppE (AppE (ConE 'Tag) (stringE tagName)) (stringE tagParent)) (tyE tagTyp)) (if tagDisambiguate then ConE 'True else ConE 'False)
+  Data -> ConE 'Data
 
 consToSwift :: ()
   => Options

--- a/src/Shwifty/Class.hs
+++ b/src/Shwifty/Class.hs
@@ -10,6 +10,7 @@ module Shwifty.Class
   , ToSwiftData(..)
   ) where
 
+import Data.Aeson (Value)
 import Data.List (intercalate)
 import Data.Proxy (Proxy(..))
 import Control.Monad.Except
@@ -21,6 +22,7 @@ import Data.Kind (Constraint)
 import Data.List.NonEmpty ((<|), NonEmpty(..))
 import Data.Maybe (mapMaybe, catMaybes)
 import Data.Proxy (Proxy(..))
+import Data.Scientific (Scientific)
 import Data.Time (UTCTime)
 import Data.UUID.Types (UUID)
 import Data.Vector (Vector)
@@ -152,3 +154,17 @@ instance forall a b. (ToSwift a, ToSwift b) => ToSwift ((,) a b) where
 
 instance forall a b c. (ToSwift a, ToSwift b, ToSwift c) => ToSwift ((,,) a b c) where
   toSwift = const (Tuple3 (toSwift (Proxy @a)) (toSwift (Proxy @b)) (toSwift (Proxy @c)))
+
+instance ToSwiftData Scientific where
+  toSwiftData _ = SwiftAlias
+    { aliasName = "Scientific"
+    , aliasTyVars = []
+    , aliasTyp = F64
+    }
+
+instance ToSwiftData Value where
+  toSwiftData _ = SwiftAlias
+    { aliasName = "Value"
+    , aliasTyVars = []
+    , aliasTyp = Data
+    }

--- a/src/Shwifty/Types.hs
+++ b/src/Shwifty/Types.hs
@@ -106,6 +106,8 @@ data Ty
     --   in a way that doesn't break Codable.
     --
     --   See 'getShwiftyWithTags' for examples.
+    | Data
+      -- ^ byte buffer in memory
   deriving stock (Eq, Show, Read)
   deriving stock (Generic)
   deriving stock (Lift)

--- a/src/Shwifty/Types.hs
+++ b/src/Shwifty/Types.hs
@@ -108,6 +108,7 @@ data Ty
     --   See 'getShwiftyWithTags' for examples.
     | Data
       -- ^ byte buffer in memory
+      --   See https://developer.apple.com/documentation/foundation/data
   deriving stock (Eq, Show, Read)
   deriving stock (Generic)
   deriving stock (Lift)


### PR DESCRIPTION
This adds a new constructor to `Ty` to represent Swift's [Data](https://developer.apple.com/documentation/foundation/data) too.

The motivation here is that these types are fairly common and it
makes sense for them to be a part of `shwifty` rather than be
implemented by hand elsewhere.